### PR TITLE
Feature/osb 603 failed deployment deletion

### DIFF
--- a/bosh/src/main/java/de/evoila/cf/cpi/bosh/BoshPlatformService.java
+++ b/bosh/src/main/java/de/evoila/cf/cpi/bosh/BoshPlatformService.java
@@ -237,7 +237,7 @@ public abstract class BoshPlatformService implements PlatformService {
                         .list(deployment.getName());
                 
                 runDeleteErrands(serviceInstance, deployment, errands);
-                log.debug("Using deployment and errands given by the bosh director.");
+                log.debug("Using the deployment and errands given by the bosh director.");
         	} catch (NullPointerException | DirectorException e) {
         		log.debug("Could not get the deployment from bosh. Creating an empty temporary one to delete the remaining VMs and the failed deployment.");
         		deployment = new Deployment();
@@ -249,7 +249,6 @@ public abstract class BoshPlatformService implements PlatformService {
                     .delete(deployment);
             waitForTaskCompletion(task.toBlocking().first());
         } catch (Exception e) {
-        	log.error("Could not delete failed service instance", e);
             throw new PlatformException("Could not delete failed service instance", e);
         }
     }

--- a/bosh/src/main/java/de/evoila/cf/cpi/bosh/BoshPlatformService.java
+++ b/bosh/src/main/java/de/evoila/cf/cpi/bosh/BoshPlatformService.java
@@ -239,8 +239,7 @@ public abstract class BoshPlatformService implements PlatformService {
                 runDeleteErrands(serviceInstance, deployment, errands);
                 log.debug("Using deployment and errands given by the bosh director.");
         	} catch (NullPointerException | DirectorException e) {
-        		log.debug(e.getMessage());
-        		log.debug("Could not get Deployment from bosh. Creating an empty temporary one to delete the remaining VMs.");
+        		log.debug("Could not get the deployment from bosh. Creating an empty temporary one to delete the remaining VMs and the failed deployment.");
         		deployment = new Deployment();
         		deployment.setName(DeploymentManager.deploymentName(serviceInstance));
         	}

--- a/bosh/src/main/java/de/evoila/cf/cpi/bosh/BoshPlatformService.java
+++ b/bosh/src/main/java/de/evoila/cf/cpi/bosh/BoshPlatformService.java
@@ -1,13 +1,31 @@
 package de.evoila.cf.cpi.bosh;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.Assert;
+
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.KeyPair;
 import com.jcraft.jsch.Session;
+
 import de.evoila.cf.broker.bean.BoshProperties;
 import de.evoila.cf.broker.controller.utils.DashboardUtils;
 import de.evoila.cf.broker.exception.PlatformException;
-import de.evoila.cf.broker.model.*;
+import de.evoila.cf.broker.model.DashboardClient;
+import de.evoila.cf.broker.model.Plan;
+import de.evoila.cf.broker.model.Platform;
+import de.evoila.cf.broker.model.ServerAddress;
+import de.evoila.cf.broker.model.ServiceInstance;
 import de.evoila.cf.broker.repository.PlatformRepository;
 import de.evoila.cf.broker.service.CatalogService;
 import de.evoila.cf.broker.service.PlatformService;
@@ -17,23 +35,13 @@ import de.evoila.cf.cpi.bosh.connection.BoshConnection;
 import de.evoila.cf.cpi.bosh.deployment.DeploymentManager;
 import de.evoila.cf.cpi.bosh.deployment.manifest.InstanceGroup;
 import de.evoila.cf.cpi.bosh.deployment.manifest.Manifest;
+import io.bosh.client.DirectorException;
 import io.bosh.client.deployments.Deployment;
 import io.bosh.client.deployments.SSHConfig;
 import io.bosh.client.errands.ErrandSummary;
 import io.bosh.client.tasks.Task;
 import io.bosh.client.vms.Vm;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.Assert;
 import rx.Observable;
-
-import javax.annotation.PostConstruct;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
 
 public abstract class BoshPlatformService implements PlatformService {
 
@@ -215,26 +223,34 @@ public abstract class BoshPlatformService implements PlatformService {
     @Override
     public void deleteInstance(ServiceInstance serviceInstance, Plan plan) throws PlatformException {
         try {
-            Deployment deployment = connection
-                    .connection()
-                    .deployments()
-                    .get(deploymentManager.getDeployment(serviceInstance).getName())
-                    .toBlocking().first();
-
-            Observable<List<ErrandSummary>> errands = connection
-                    .connection()
-                    .errands()
-                    .list(deployment.getName());
-
-            runDeleteErrands(serviceInstance, deployment, errands);
-
+        	Deployment deployment = null;
+        	Observable<List<ErrandSummary>> errands = null;
+        	try {
+        		deployment = connection
+                        .connection()
+                        .deployments()
+                        .get(deploymentManager.getDeployment(serviceInstance).getName())
+                        .toBlocking().first();
+                errands = connection
+                        .connection()
+                        .errands()
+                        .list(deployment.getName());
+                
+                runDeleteErrands(serviceInstance, deployment, errands);
+                log.debug("Using deployment and errands given by the bosh director.");
+        	} catch (NullPointerException | DirectorException e) {
+        		log.debug(e.getMessage());
+        		log.debug("Could not get Deployment from bosh. Creating an empty temporary one to delete the remaining VMs.");
+        		deployment = new Deployment();
+        		deployment.setName(DeploymentManager.deploymentName(serviceInstance));
+        	}
             Observable<Task> task = connection
                     .connection()
                     .deployments()
                     .delete(deployment);
-
             waitForTaskCompletion(task.toBlocking().first());
         } catch (Exception e) {
+        	log.error("Could not delete failed service instance", e);
             throw new PlatformException("Could not delete failed service instance", e);
         }
     }

--- a/bosh/src/main/java/de/evoila/cf/cpi/bosh/deployment/DeploymentManager.java
+++ b/bosh/src/main/java/de/evoila/cf/cpi/bosh/deployment/DeploymentManager.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import de.evoila.cf.broker.bean.BoshProperties;
 import de.evoila.cf.broker.model.*;
+import de.evoila.cf.broker.util.GlobalConstants;
 import de.evoila.cf.broker.util.MapUtils;
 import de.evoila.cf.cpi.bosh.deployment.manifest.InstanceGroup;
 import de.evoila.cf.cpi.bosh.deployment.manifest.Manifest;
@@ -14,6 +15,7 @@ import de.evoila.cf.cpi.bosh.deployment.manifest.Stemcell;
 import io.bosh.client.deployments.Deployment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.util.Assert;
 
@@ -21,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -30,12 +33,16 @@ public class DeploymentManager {
 
     protected final Logger log = LoggerFactory.getLogger(this.getClass());
 
-    private static final String DEPLOYMENT_PREFIX = "sb-";
+    private static String DEPLOYMENT_PREFIX = "sb-";
 
     protected static final String NODES = "nodes";
+
     protected static final String VM_TYPE = "vm_type";
+
     protected static final String NETWORKS = "networks";
+
     protected static final String DISK_TYPE = "persistent_disk_type";
+
     protected static final String STEMCELL_VERSION = "stemcell_version";
 
     private final ObjectReader reader;
@@ -43,12 +50,19 @@ public class DeploymentManager {
 
     protected final BoshProperties boshProperties;
 
-    public DeploymentManager(BoshProperties properties) {
+    public DeploymentManager(BoshProperties properties, Environment environment) {
         Assert.notNull(properties, "Bosh Properties cant be null");
         this.mapper = new ObjectMapper(new YAMLFactory());
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_DEFAULT);
+        this.mapper.setSerializationInclusion(JsonInclude.Include.NON_DEFAULT);
         this.boshProperties = properties;
         this.reader = mapper.readerFor(Manifest.class);
+
+        if (environment != null) {
+            if (Arrays.stream(environment.getActiveProfiles()).anyMatch(
+                    env -> (env.equalsIgnoreCase(GlobalConstants.TEST_PROFILE)))) {
+                this.DEPLOYMENT_PREFIX = "sb-test-";
+            }
+        }
     }
 
     protected void replaceParameters(ServiceInstance instance, Manifest manifest, Plan plan, Map<String, Object> customParameters) {


### PR DESCRIPTION
Adds an other try to delete a deployment, after the initial try fails because of an empty manifest at the director side.