### PR TITLE
fix(BoshPlattformService): cleanup provision if it fails

### DIFF
--- a/bosh/src/main/java/de/evoila/cf/cpi/bosh/BoshPlatformService.java
+++ b/bosh/src/main/java/de/evoila/cf/cpi/bosh/BoshPlatformService.java
@@ -42,11 +42,11 @@ import java.io.IOException;
 import java.util.*;
 
 /**
- * @author Yannic Remmet, Johannes Hiemer.
+ * @author Yannic Remmet, Johannes Hiemer, Johannes Strauß.
  */
 public abstract class BoshPlatformService implements PlatformService {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     private static final String QUEUED = "queued";
 
@@ -220,6 +220,7 @@ public abstract class BoshPlatformService implements PlatformService {
         } catch (IOException e) {
             log.error("Couldn't create Service Instance via Bosh Deployment");
             log.error(e.getMessage());
+            cleanUp(in, plan);
             throw new PlatformException("Could not create Service Instance", e);
         }
         return instance;
@@ -290,8 +291,8 @@ public abstract class BoshPlatformService implements PlatformService {
     @Override
     public void deleteInstance(ServiceInstance serviceInstance, Plan plan) throws PlatformException {
         try {
-            Deployment deployment = null;
-            Observable<List<ErrandSummary>> errands = null;
+            Deployment deployment;
+            Observable<List<ErrandSummary>> errands;
             try {
                 deployment = boshClient
                         .client()
@@ -323,8 +324,6 @@ public abstract class BoshPlatformService implements PlatformService {
     @Override
     public void postDeleteInstance(ServiceInstance serviceInstance) throws PlatformException {
     }
-
-    ;
 
     @Override
     public ServiceInstance getInstance(ServiceInstance serviceInstance, Plan plan) throws PlatformException {
@@ -433,4 +432,12 @@ public abstract class BoshPlatformService implements PlatformService {
         return deploymentManager.readManifestFromString(manifest);
     }
 
+    private void cleanUp(ServiceInstance serviceInstance, Plan plan) {
+        log.error("Cleaning up failed Service Instance: " + serviceInstance.getId());
+        try {
+            deleteInstance(serviceInstance, plan);
+        } catch (PlatformException e) {
+            log.error("Clean up Failed with cause: ", e);
+        }
+    }
 }

--- a/bosh/src/main/java/de/evoila/cf/cpi/bosh/BoshPlatformService.java
+++ b/bosh/src/main/java/de/evoila/cf/cpi/bosh/BoshPlatformService.java
@@ -437,7 +437,7 @@ public abstract class BoshPlatformService implements PlatformService {
         try {
             deleteInstance(serviceInstance, plan);
         } catch (PlatformException e) {
-            log.error("Clean up Failed with cause: ", e);
+            log.error("Clean up Failed with exception: ", e);
         }
     }
 }


### PR DESCRIPTION
Run delete service instance when provision fails, then log exception.